### PR TITLE
Feature/download only latest git version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .cache
 *.pyc
 output/
-env/
 .idea/
+*.DS_Store
+env/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once spaCy 2.0 is configured at the root directory as spacy-training, and you pr
 Docker
 ----------
 Using docker is the easiest way of processing the models. You can just go into docker directory and build the image:
-```
+```bash
 docker-compose build --build-arg GITHUB_SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)"
 ```
 `GITHUB_SSH_PRIVATE_KEY` is the key for your Github Account, that needs to have write permission on any fork from spaCy [repository](https://github.com/explosion/spaCy.git).
@@ -49,7 +49,7 @@ GITHUB_USERNAME: Username of the Github account that will receive languages feat
 GITHUB_EMAIL: Email of the Github account that will receive language features;
 ```
 Finally, you can run the up command to start processing:
-```
+```bash
 docker-compose up
 ```
 
@@ -57,7 +57,7 @@ Testing
 -------
 
 We use pytest for testing. Run all tests with:
-```
+```bash
 python3 -m pytest
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR ${APP_HOME}
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-RUN git clone --branch feature/processing https://github.com/ilhasoft/spaCy.git $SPACY_HOME
+RUN git clone --branch feature/processing --depth=1 https://github.com/ilhasoft/spaCy.git $SPACY_HOME
 
 RUN pip install --no-cache-dir -r $SPACY_HOME/requirements.txt
 RUN pip install -e $SPACY_HOME


### PR DESCRIPTION
Change script to download spaCy with `depth=1`. This prevents the docker instance form downloading the whole spaCy history every time it runs.